### PR TITLE
Add per-profile Nemirtingas Epic config binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ You'll need to install KDE Plasma, Gamescope, and Bubblewrap using your distro's
 ### Getting Started
 Once in the main menu, click the + button to add a game: this can be just a regular Linux executable, a Windows game (.exe), or a PartyDeck Handler (.pdh). Create profiles if you want to store save data, and have a look through the settings menu.
 
+### Nemirtingas Epic Emu
+Some games ship a patched `EOSSDK-Win64-Shipping.dll` that reads a
+`NemirtingasEpicEmu.json` configuration. Handlers can expose this by
+adding an `eos.config_path` field pointing to the expected location of the
+JSON file **relative to the game's root directory**. This path should
+include the file name itself. For example, if the DLL loads
+`nepice_settings/NemirtingasEpicEmu.json` next to it, add
+`"eos.config_path": "nepice_settings/NemirtingasEpicEmu.json"` to the
+handler. PartyDeck will then create a per-profile JSON and bind it to that
+location when launching the game. Each profile's file sets both `epicid`
+and `username` to the profile name so player identity remains constant
+across sessions. The patched `EOSSDK` DLL is **not** bundled with
+PartyDeck; handlers should include it themselves. Place
+`EOSSDK-Win64-Shipping.dll` inside the handler's `copy_to_symdir` folder
+mirroring where the game expects it so PartyDeck can copy or symlink it
+into the game directory at launch.
+
+
 ## Building
 
 To build PartyDeck, You'll need a Rust toolchain installed with the 2024 Edition. For the mouse/keyboard gamescope build, you'll need ninja and meson installed.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -30,6 +30,10 @@ pub struct Handler {
     pub dll_overrides: Vec<String>,
 
     pub path_goldberg: String,
+    // Path to Nemirtingas config relative to the game's root directory.
+    // The handler must also bundle the patched EOSSDK DLL (e.g. via
+    // copy_to_symdir) at the matching location; PartyDeck does not ship it.
+    pub path_nemirtingas: String,
     pub steam_appid: Option<String>,
     pub coldclient: bool,
 
@@ -114,6 +118,11 @@ impl Handler {
                 .unwrap_or_default(),
 
             path_goldberg: json["steam.api_path"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string()
+                .sanitize_path(),
+            path_nemirtingas: json["eos.config_path"]
                 .as_str()
                 .unwrap_or_default()
                 .to_string()

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -248,6 +248,17 @@ pub fn launch_cmd(
                     "--bind \"{path_prof}/steam\" \"{gamedir}/{path_goldberg}/goldbergsave\" "
                 ));
             }
+            if !h.path_nemirtingas.is_empty() {
+                let src = format!("{path_prof}/NemirtingasEpicEmu.json");
+                let dest = PathBuf::from(gamedir).join(&h.path_nemirtingas);
+                if let Some(parent) = dest.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                binds.push_str(&format!(
+                    "--bind \\\"{src}\\\" \\\"{}\\\" ",
+                    dest.to_string_lossy()
+                ));
+            }
             if h.win {
                 let path_windata = format!("{pfx}/drive_c/users/steamuser/");
                 if h.win_unique_appdata {

--- a/src/util/filesystem.rs
+++ b/src/util/filesystem.rs
@@ -161,9 +161,7 @@ impl SanitizePath for String {
         // Allow single quotes in paths since they are quoted when launching
         // commands. Double quotes would break the quoting though, so we still
         // strip those along with other potentially dangerous characters.
-        let chars_to_sanitize = [
-            ';', '&', '|', '$', '`', '(', ')', '<', '>', '"', '\\', '/',
-        ];
+        let chars_to_sanitize = [';', '&', '|', '$', '`', '(', ')', '<', '>', '"', '\\', '/'];
 
         if chars_to_sanitize.iter().any(|&c| sanitized.contains(c)) {
             sanitized = sanitized

--- a/src/util/profiles.rs
+++ b/src/util/profiles.rs
@@ -1,4 +1,5 @@
 use rand::prelude::*;
+use serde_json::json;
 use std::error::Error;
 use std::path::PathBuf;
 
@@ -20,6 +21,21 @@ pub fn create_profile(name: &str) -> Result<(), std::io::Error> {
         "[user::general]\naccount_name={name}\naccount_steamid={steam_id}\nlanguage=english\nip_country=US"
     );
     std::fs::write(path_steam.join("configs.user.ini"), usersettings)?;
+
+    let nepice_path = PATH_PARTY.join(format!("profiles/{name}/NemirtingasEpicEmu.json"));
+    if !nepice_path.exists() {
+        let cfg = json!({
+            "enable_overlay": false,
+            "epicid": name,
+            "disable_online_networking": false,
+            "enable_lan": true,
+            "savepath": "appdata",
+            "unlock_dlcs": true,
+            "language": "en",
+            "username": name
+        });
+        std::fs::write(&nepice_path, serde_json::to_string_pretty(&cfg).unwrap())?;
+    }
 
     println!("Created successfully");
     Ok(())


### PR DESCRIPTION
## Summary
- generate NemirtingasEpicEmu.json per profile with unique user data
- allow handlers to declare EOS config path via `eos.config_path`
- bind each profile's Nemirtingas config into game directory at launch
- document `eos.config_path` usage, default user data fields, and that handlers must supply the patched EOSSDK DLL via `copy_to_symdir`

## Testing
- _No tests run_


------
https://chatgpt.com/codex/tasks/task_e_68a9b9987c54832a88476bdce9472d6a