### PR TITLE
Skip missing Nemirtingas config during launch

### DIFF
--- a/src/launch.rs
+++ b/src/launch.rs
@@ -249,15 +249,18 @@ pub fn launch_cmd(
                 ));
             }
             if !h.path_nemirtingas.is_empty() {
-                let src = format!("{path_prof}/NemirtingasEpicEmu.json");
-                let dest = PathBuf::from(gamedir).join(&h.path_nemirtingas);
-                if let Some(parent) = dest.parent() {
-                    std::fs::create_dir_all(parent)?;
+                let src = PathBuf::from(format!("{path_prof}/NemirtingasEpicEmu.json"));
+                if src.exists() {
+                    let dest = PathBuf::from(gamedir).join(&h.path_nemirtingas);
+                    if let Some(parent) = dest.parent() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+                    binds.push_str(&format!(
+                        "--bind \\\"{}\\\" \\\"{}\\\" ",
+                        src.to_string_lossy(),
+                        dest.to_string_lossy()
+                    ));
                 }
-                binds.push_str(&format!(
-                    "--bind \\\"{src}\\\" \\\"{}\\\" ",
-                    dest.to_string_lossy()
-                ));
             }
             if h.win {
                 let path_windata = format!("{pfx}/drive_c/users/steamuser/");


### PR DESCRIPTION
## Summary
- Avoid binding NemirtingasEpicEmu.json when profile lacks the file to prevent launch failure

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68a9e0cfd958832aa374c48635a98ec4