### PR TITLE
feat: enforce per-instance Nemirtingas config

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -7,7 +7,8 @@ mod updates;
 
 // Re-export functions from profiles
 pub use profiles::{
-    GUEST_NAMES, create_gamesave, create_profile, remove_guest_profiles, scan_profiles,
+    GUEST_NAMES, create_gamesave, create_profile, ensure_nemirtingas_config,
+    remove_guest_profiles, scan_profiles,
 };
 
 // Re-export functions from filesystem


### PR DESCRIPTION
## Summary
- ensure per-profile Nemirtingas config file is created with stable IDs and logged
- harden copy/mirror logic with exclude list so Nemirtingas JSON is never symlinked
- log SHA1 and real paths before binding Nemirtingas config for each instance

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68aa17c83ba4832a941fd6e50d815477