### PR TITLE
Fix Windows launch path canonicalization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+- Only run automated tests or checks when implementing large or complex changes. Small tweaks spanning just a few lines do not require executing the test suite.
+- Comment each newly introduced code block to document its purpose clearly.
+- Preserve existing functionality: double-check for syntax errors or regressions before finalizing changes.
+- For UI changes, ensure a modern, well-aligned, and consistent presentation without unnecessary spacing around elements.

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -382,8 +382,17 @@ pub fn launch_game(
             cmd.arg(&runtime);
         }
 
-        let exec_path = format!("{instance_gamedir}/{exec}");
-        cmd.arg(exec_path);
+        // Resolve the executable path and canonicalize it for Windows builds so Proton receives
+        // the real filesystem target instead of a symlink path that certain games refuse to open.
+        let exec_path = PathBuf::from(&instance_gamedir).join(&exec);
+        let exec_arg = if win {
+            exec_path
+                .canonicalize()
+                .unwrap_or_else(|_| exec_path.clone())
+        } else {
+            exec_path.clone()
+        };
+        cmd.arg(exec_arg.to_string_lossy().to_string());
 
         let args: Vec<String> = match game {
             HandlerRef(h) => h


### PR DESCRIPTION
## Summary
- canonicalize Windows executable paths before launching so Proton resolves the real file when handlers use symlinked game directories
- document high level workflow expectations for contributors in a new AGENTS.md

## Testing
- no tests were run (not required for this change)


------
https://chatgpt.com/codex/tasks/task_e_68d3ebe10428832a8b9b95af0567e6a1