### PR TITLE
Silence compiler warnings

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -38,9 +38,6 @@ impl Executable {
     pub fn filename(&self) -> &str {
         &self.filename
     }
-    pub fn args(&self) -> &str {
-        &self.args
-    }
 }
 
 pub enum Game {

--- a/src/input.rs
+++ b/src/input.rs
@@ -33,7 +33,6 @@ pub enum PadButton {
 #[derive(Clone)]
 pub struct DeviceInfo {
     pub path: String,
-    pub vendor: u16,
     pub enabled: bool,
     pub device_type: DeviceType,
 }
@@ -69,9 +68,6 @@ impl InputDevice {
     pub fn path(&self) -> &str {
         &self.path
     }
-    pub fn vendor(&self) -> u16 {
-        self.dev.input_id().vendor()
-    }
     pub fn enabled(&self) -> bool {
         self.enabled
     }
@@ -84,7 +80,6 @@ impl InputDevice {
     pub fn info(&self) -> DeviceInfo {
         DeviceInfo {
             path: self.path().to_string(),
-            vendor: self.vendor(),
             enabled: self.enabled(),
             device_type: self.device_type(),
         }

--- a/src/util/lock.rs
+++ b/src/util/lock.rs
@@ -85,7 +85,7 @@ impl ProfileLock {
     }
 
     pub fn cleanup(&self) {
-        let _ = self.file.unlock();
+        let _ = FileExt::unlock(&self.file);
         let _ = std::fs::remove_file(&self.path);
     }
 }


### PR DESCRIPTION
## Summary
- call the fs2 unlock method with fully-qualified syntax to avoid the unstable_name_collisions warning
- remove the unused Executable::args accessor
- drop the unused vendor field from DeviceInfo to silence the dead_code warning

## Testing
- not run (small change)


------
https://chatgpt.com/codex/tasks/task_e_68d3f5c4c2d8832ab20183b8daac2480