### PR TITLE
Bind Nemirtingas debug log inside the sandbox

### DIFF
--- a/src/launch.rs
+++ b/src/launch.rs
@@ -474,9 +474,7 @@ pub fn launch_game(
                     nemirtingas_binds.push((json_path.clone(), dest_path.clone()));
                 }
 
-                if let Some(runtime_parent) =
-                    nemirtingas_rel.parent().and_then(|parent| parent.parent())
-                {
+                if let Some(runtime_parent) = nemirtingas_rel.parent() {
                     let runtime_log = PathBuf::from(&instance_gamedir)
                         .join(runtime_parent)
                         .join("NemirtingasEpicEmu.log");


### PR DESCRIPTION
## Summary
- ensure the Nemirtingas runtime log bind mounts to the same directory as its config when using bubblewrap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d553f1bb44832a9f6e1e4eaa14499a