### PR TITLE
Generate persistent Nemirtingas IDs per profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,4 @@
 - For UI changes, ensure a modern, well-aligned, and consistent presentation without unnecessary spacing around elements.
 - Default Nemirtingas configuration log levels to debug severity so multiplayer invite issues remain inspectable.
 - Persist launch warnings to a text log under the PARTY directory in addition to printing them to the console for easier debugging.
+- Generate and persist unique Nemirtingas `EpicId`/`ProductUserId` pairs for each profile so invite codes stay stable between sessions.


### PR DESCRIPTION
## Summary
- generate deterministic Nemirtingas EpicId/ProductUserId pairs when a profile is missing them and log the assignment
- store the generated IDs in both the nested and legacy JSON fields so Nemirtingas reuses them across launches
- document the requirement in AGENTS.md to keep profile IDs stable for invite testing

## Testing
- no automated tests were run (not required for this change)

------
https://chatgpt.com/codex/tasks/task_e_68d570e99c34832a95355baed1d2ac34