### PR TITLE
Mirror Nemirtingas Proton logs into profile files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,4 @@
 - Default Nemirtingas configuration log levels to debug severity so multiplayer invite issues remain inspectable.
 - Persist launch warnings to a text log under the PARTY directory in addition to printing them to the console for easier debugging.
 - Generate and persist unique Nemirtingas `EpicId`/`ProductUserId` pairs for each profile so invite codes stay stable between sessions.
+- Capture any newly provided project-wide user instructions in this file so they are not forgotten on future tasks.


### PR DESCRIPTION
## Summary
- add a Nemirtingas log mirror worker that tails Proton AppData logs and appends them to each profile's Nemirtingas log
- hook the mirror into the Windows launch path so every Proton instance starts and stops its own log sync alongside the game process

## Testing
- cargo check *(fails: system dependency libarchive is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d588dc6c28832a8b28da642bec78ae