### PR TITLE
Force EOS LAN port to match Goldberg listen_port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,5 +7,6 @@
 - Default Nemirtingas configuration log levels to debug severity so multiplayer invite issues remain inspectable.
 - Persist launch warnings to a text log under the PARTY directory in addition to printing them to the console for easier debugging.
 - Generate and persist unique Nemirtingas `EpicId`/`ProductUserId` pairs for each profile so invite codes stay stable between sessions.
+- Keep Nemirtingas/EOS LAN discovery aligned with Goldberg by forcing `EOS_OVERRIDE_LAN_PORT` to the same port exposed via `listen_port.txt`.
 - Capture any newly provided project-wide user instructions in this file so they are not forgotten on future tasks.
 - When a task exposes a recurring mistake or introduces a new global rule from the user, document it here immediately so future work remains aligned.

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -9,7 +9,7 @@ mod updates;
 // Re-export functions from profiles
 pub use profiles::{
     GUEST_NAMES, create_gamesave, create_profile, ensure_nemirtingas_config, remove_guest_profiles,
-    scan_profiles,
+    scan_profiles, synchronize_goldberg_profiles,
 };
 
 // Re-export functions from filesystem


### PR DESCRIPTION
## Summary
- synchronize Goldberg listen port and identity helper files across active profiles before launch
- bind each profile's Nemirtingas directory into the runtime tree so EOS state, logs, and appdata stay isolated per instance
- update Goldberg configs and set EOS_OVERRIDE_LAN_PORT so Goldberg and Nemirtingas share the same LAN discovery socket

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68d674ab4c94832a9166fd9908f2d123