### PR TITLE
Stabilize Nemirtingas LAN port allocation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@
 - Default Nemirtingas configuration log levels to debug severity so multiplayer invite issues remain inspectable.
 - Persist launch warnings to a text log under the PARTY directory in addition to printing them to the console for easier debugging.
 - Generate and persist unique Nemirtingas `EpicId`/`ProductUserId` pairs for each profile so invite codes stay stable between sessions.
-- Keep Nemirtingas/EOS LAN discovery aligned with Goldberg by forcing `EOS_OVERRIDE_LAN_PORT` to the same port exposed via `listen_port.txt`.
-- When a handler ships a Nemirtingas config (`eos.config_path`), pin Goldberg's LAN port to `55789` so both emulators advertise on the same socket while leaving non-Nemirtingas titles untouched.
+- Prefer distinct UDP sockets for Nemirtingas LAN beacons and Goldberg discovery. Force `EOS_OVERRIDE_LAN_PORT` to the deterministic Nemirtingas port exposed in profile configs instead of mirroring Goldberg's `listen_port.txt`, since sharing the same socket causes the emulator to auto-increment per instance.
+- When a handler ships a Nemirtingas config (`eos.config_path`), still normalize Goldberg `listen_port` deterministically but allow it to remain independent from Nemirtingas so both systems keep stable yet non-conflicting sockets.
 - Default Goldberg `gc_token`/`new_app_ticket` toggles to `1` (files and INI flags) so the experimental steam_api build bundled in `res/goldberg` works without manual edits.
 - Keep Goldberg's `auto_accept_invite.txt` empty when enabling auto-accept so the experimental overlay bypass matches upstream documentation; avoid writing sentinel values like `1`.
 - Capture any newly provided project-wide user instructions in this file so they are not forgotten on future tasks.

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -9,7 +9,7 @@ mod updates;
 // Re-export functions from profiles
 pub use profiles::{
     GUEST_NAMES, create_gamesave, create_profile, ensure_nemirtingas_config, remove_guest_profiles,
-    scan_profiles, synchronize_goldberg_profiles,
+    resolve_nemirtingas_port, scan_profiles, synchronize_goldberg_profiles,
 };
 
 // Re-export functions from filesystem


### PR DESCRIPTION
## Summary
- document the new Nemirtingas and Goldberg port separation so future changes stop forcing the emulators onto the same socket
- resolve a deterministic Nemirtingas LAN port per game and reuse it across instances while keeping Goldberg discovery untouched
- expose the resolver through the util module and propagate the port to launcher configuration and environment overrides

## Testing
- cargo check *(fails: compress-tools requires system libarchive in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6de246f00832aaecea17ad9645500