### PR TITLE
Silence unused assignment warnings in profile INI helper

### DIFF
--- a/src/launch.rs
+++ b/src/launch.rs
@@ -187,7 +187,7 @@ fn spawn_nemirtingas_log_mirror(
         offsets.retain(|path, _| path.exists());
         for (source, offset) in offsets {
             if let Ok(metadata) = fs::metadata(&source) {
-                let mut local_offset = offset.min(metadata.len());
+                let local_offset = offset.min(metadata.len());
                 if metadata.len() > local_offset {
                     if let Ok(mut src) = std::fs::File::open(&source) {
                         if src.seek(SeekFrom::Start(local_offset)).is_ok() {

--- a/src/util/profiles.rs
+++ b/src/util/profiles.rs
@@ -185,8 +185,6 @@ fn ensure_ini_setting(path: &Path, section: &str, key: &str, value: &str) -> io:
         }
         lines.push(desired_section.to_string());
         lines.push(desired_key.clone());
-        section_found = true;
-        key_updated = true;
     } else if !key_updated {
         let mut insert_index = lines.len();
         let mut current_section = None;


### PR DESCRIPTION
## Summary
- remove redundant section/key flag updates inside the INI editing helper
- silence the remaining compiler warnings emitted during the build

## Testing
- cargo build

------
https://chatgpt.com/codex/tasks/task_e_68d6e5291134832aaf5c47034bff9090